### PR TITLE
Signalling duplicates in store_key

### DIFF
--- a/ffhash_inc.f90
+++ b/ffhash_inc.f90
@@ -205,12 +205,20 @@ contains
        ! not at its 'first' hash index, and some keys in between have been deleted.
        do step = 1, h%n_buckets
           if (bucket_empty(h, i)) exit
-          if (.not. bucket_deleted(h, i) &
-               .and. keys_equal(h%keys(i), key)) exit
+          !modByRT - begin
+          !If key is already present, set i = -2
+          if (.not. bucket_deleted(h, i).and.&
+             keys_equal(h%keys(i), key)) then
+               i = -2
+               return
+          end if
+          !if (.not. bucket_deleted(h, i) &
+          !     .and. keys_equal(h%keys(i), key)) exit
+          !modByRT - end
           if (bucket_deleted(h, i)) i_deleted = i
           i = next_index(h, i, step)
        end do
-
+       
        if (bucket_empty(h, i) .and. i_deleted /= -1) then
           ! Use deleted location. By taking the last one, the deleted sequence
           ! is shrunk from the end.
@@ -228,7 +236,6 @@ contains
        h%keys(i)       = key
        call set_bucket_filled(h, i)
     end if
-    ! If key is already present, do nothing
 
   end subroutine store_key
 


### PR DESCRIPTION
Thanks for this utility, it has been very helpful in my projects.

This pull request adds a flag to subroutine `store_key` to handle the case when the key is already in the hashmap.
If a duplicate is found, the routine now returns `-2`.
This makes it easier to check for and handle duplicates directly.

The patch has been tested and runs correctly.

Would you be able to add this improvement to the project?

Thanks for considering this potential update.