### PR TITLE
Extended configuration macros, custom key support, and 64-bit hash option

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,14 +36,29 @@ module m_example
 end module m_example
 ```
 
-The following preprocessor commands can be used:
+The following preprocessor commands can be used (on the input side):
 
-* `#define FFH_KEY_TYPE` (required) followed by a type name (e.g., `integer`, `real`, `type(my_type)`
+* `#define FFH_KEY_TYPE` (required) followed by a type name (e.g., `integer`, `real`, `type(my_type)`).  
+   This is the type of the keys stored in the hash table.  
+* `#define FFH_STRING_KEY_TYPE` followed by a character type declaration (e.g., `character(len=15)`).  
+  This is an alternative for `FFH_KEY_TYPE` used for string keys.  
+  (If defined, `FFH_KEY_TYPE = FFH_STRING_KEY_TYPE` will be set automatically in `ffhash_inc.f90`.)
+* `#define FFH_VAL_TYPE` (optional) followed by a type name, so that keys can be associated with values.  
+* `#define FFH_STRING_VAL_TYPE` (optional) followed by a character type declaration (e.g., `character(len=30)`).  
+  This is an alternative for `FFH_VAL_TYPE` used for string values.  
+  (`FFH_VAL_TYPE = FFH_STRING_VAL_TYPE` will be set automatically in `ffhash_inc.f90`.)  
+* `#define FFH_KEY_TYPE` (required) followed by a type name (e.g., `integer`, `real`, `type(my_type)`  
 * `#define FFH_VAL_TYPE` (optional) followed by a type name, so that keys can be associated with values.
-* `#define FFH_KEY_IS_STRING` (optional) for string key types. This allows to use keys shorter than the maximum length. Note that in Fortran "a" == "a " (trailing spaces are ignored).
-* `#define FFH_VAL_IS_STRING` (optional), similar to `FFH_KEY_IS_STRING`.
-* `#define FFH_CUSTOM_HASH_FUNCTION` (optional) to define a custom hash function (after the `#include "ffhash_inc.f90"` line).
-* `#define FFH_CUSTOM_KEYS_EQUAL` (optional) to define a custom function for comparing keys (after the `#include "ffhash_inc.f90"` line).
+* `#define FFH_ENABLE_INT64` (optional) to use 64-bit integers internally for bucket indices, counters, and hash values.  
+  This allows handling very large tables (more than 2 billion buckets or keys).  
+  If undefined, 32-bit integers are used by default, which is usually sufficient and slightly faster.  
+* `#define FFH_CUSTOM_KEYS_EQUAL` (optional) to define a custom function for comparing keys  
+   (after the `#include "ffhash_inc.f90"` line).
+* `#define FFH_CUSTOM_CONVERT_KEY` (optional) to convert the key into a `character` buffer suitable for hashing.  
+   This gives full control over how keys are serialized (e.g., for derived types).  
+   If undefined, the library supplies default conversions for string and non-string keys.  
+* `#define FFH_CUSTOM_HASH_FUNCTION` (optional) to define a custom hash function  
+   (after the `#include "ffhash_inc.f90"` line).
 
 A type `ffh_t` can be used after importing the created module, for example like this:
 
@@ -71,7 +86,7 @@ do i = 0, h%n_buckets-1
 end do
 ```
 
-Below is the full list of included methods. The variants starting with a `u` call `error stop` in case of errors. The variants without a `u` have an additional `status` argument, which is `-1` in case of errors.
+Below is the full list of (public) methods included. The variants starting with a `u` call `error stop` in case of errors. The variants without a `u` have an additional `status` argument, which is `-1` in case of errors.
 
 | name | description |
 |---|---|
@@ -87,6 +102,7 @@ Below is the full list of included methods. The variants starting with a `u` cal
 | `resize` | Manually resize the hash table (happens automatically) |
 | `reset` | Reset the hash table to initial empty state |
 | `hash_function` | Hash function |
+| `convert_key`      | Function to convert a key to a string buffer before hashing (optional, user-supplied) |
 
 Links
 ==

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The following preprocessor commands can be used (on the input side):
   (`FFH_VAL_TYPE = FFH_STRING_VAL_TYPE` will be set automatically in `ffhash_inc.f90`.)  
 * `#define FFH_KEY_TYPE` (required) followed by a type name (e.g., `integer`, `real`, `type(my_type)`  
 * `#define FFH_VAL_TYPE` (optional) followed by a type name, so that keys can be associated with values.
-* `#define FFH_ENABLE_INT64` (optional) to use 64-bit integers internally for bucket indices, counters, and hash values.  
+* `#define FFH_ENABLE_INT64` (optional) to use 64-bit integers for bucket indices, counters, and hash values.  
   This allows handling very large tables (more than 2 billion buckets or keys).  
   If undefined, 32-bit integers are used by default, which is usually sufficient and slightly faster.  
 * `#define FFH_CUSTOM_KEYS_EQUAL` (optional) to define a custom function for comparing keys  

--- a/example_benchmark.f90
+++ b/example_benchmark.f90
@@ -1,4 +1,5 @@
 module m_ffhash
+  use iso_fortran_env
   implicit none
 #define FFH_KEY_TYPE integer
 #include "ffhash_inc.f90"

--- a/example_custom_hash_function.f90
+++ b/example_custom_hash_function.f90
@@ -1,7 +1,7 @@
 module m_ffhash
+  use iso_fortran_env
   implicit none
-#define FFH_KEY_TYPE character(len=20)
-#define FFH_KEY_IS_STRING
+#define FFH_STRING_KEY_TYPE character(len=20)
 #define FFH_VAL_TYPE integer
 #define FFH_CUSTOM_HASH_FUNCTION
 #include "ffhash_inc.f90"

--- a/example_custom_types.f90
+++ b/example_custom_types.f90
@@ -17,26 +17,84 @@ module m_example
   end function keys_equal
 end module m_example
 
+module m_example_2
+  use iso_fortran_env
+  implicit none
+
+  type, public :: my_type_2
+     integer, allocatable :: x(:)
+  end type my_type_2
+
+#define FFH_KEY_TYPE type(my_type_2)
+#define FFH_CUSTOM_KEYS_EQUAL
+#define FFH_CUSTOM_CONVERT_KEY
+#define FFH_VAL_TYPE integer(int64)
+#include "ffhash_inc.f90"
+
+  pure logical function keys_equal(a, b)
+    type(my_type_2), intent(in) :: a, b
+    keys_equal = size(a%x) == size(b%x)
+    if (keys_equal) keys_equal = all(a%x == b%x)
+  end function keys_equal
+
+  pure function convert_key(a) result(bstring)
+    type(my_type_2), intent(in) :: a
+    character(len=size(a%x)*4)  :: bstring
+    bstring = transfer(a%x, bstring)
+  end function convert_key
+end module m_example_2
+
 program test
   use m_example
+  use m_example_2, ffh2_t => ffh_t
   use iso_fortran_env
 
   implicit none
 
-  type(ffh_t) :: h
-  type(my_type) :: x, y
+  call test_1()
+  call test_2()
 
-  x%n = 123
-  y%n = 345
+contains
 
-  call h%ustore_value(x, 1024_int64)
-  call h%ustore_value(y, 2048_int64)
+  subroutine test_1()
+    type(ffh_t) :: h
+    type(my_type) :: x, y
 
-  if (h%fget_value(x) == 1024_int64) then
-     print *, "PASSED"
-  else
-     error stop "FAILED"
-  end if
+    x%n = 123
+    y%n = 345
 
-  call h%reset()
+    call h%ustore_value(x, 1024_int64)
+    call h%ustore_value(y, 2048_int64)
+
+    if (h%fget_value(x) == 1024_int64) then
+       print *, "PASSED"
+    else
+       error stop "FAILED"
+    end if
+
+    call h%reset()
+  end subroutine test_1
+
+  subroutine test_2()
+    type(ffh2_t) :: h
+    type(my_type_2) :: a, b, c
+
+    allocate(a%x(5), b%x(3), c%x(3))
+    a%x = [1, 2, 3, 4, 5]
+    b%x = [3, 2, 1]
+    c%x = [1, 2, 3]
+
+    call h%ustore_value(a, 1024_int64)
+    call h%ustore_value(b, 2048_int64)
+    call h%ustore_value(c, 4096_int64)
+
+    if (h%fget_value(a) == 1024_int64) then
+       print *, "PASSED"
+    else
+       error stop "FAILED"
+    end if
+
+    call h%reset()
+  end subroutine test_2
+
 end program test

--- a/example_multiple_tables.f90
+++ b/example_multiple_tables.f90
@@ -1,45 +1,82 @@
-module m_hash_a
+module m_hash_a 
+  use iso_fortran_env
   implicit none
 #define FFH_KEY_TYPE integer
-#define FFH_VAL_TYPE character(len=15)
-#define FFH_VAL_IS_STRING
+#define FFH_STRING_VAL_TYPE character(len=15)
 #include "ffhash_inc.f90"
 end module m_hash_a
 
 module m_hash_b
+  use iso_fortran_env
   implicit none
-#define FFH_KEY_TYPE character(len=20)
-#define FFH_KEY_IS_STRING
+#define FFH_STRING_KEY_TYPE character(len=20)
 #define FFH_VAL_TYPE integer
 #include "ffhash_inc.f90"
 end module m_hash_b
 
+module m_hash_c
+  use iso_fortran_env
+  implicit none
+#define FFH_ENABLE_INT64
+#define FFH_KEY_TYPE integer(int64)
+#define FFH_VAL_TYPE integer(int64)
+#include "ffhash_inc.f90"
+end module m_hash_c
+
+module m_hash_d
+  use iso_fortran_env
+  implicit none
+#define FFH_ENABLE_INT64
+#define FFH_KEY_TYPE integer(int64)
+#define FFH_STRING_VAL_TYPE character(len=31)
+#include "ffhash_inc.f90"
+end module m_hash_d
+
 program test
+  use iso_fortran_env, only: int64
   use m_hash_a, ffha_t => ffh_t
   use m_hash_b, ffhb_t => ffh_t
+  use m_hash_c, ffhc_t => ffh_t
+  use m_hash_d, ffhd_t => ffh_t
   implicit none
 
   type(ffha_t) :: ha
   type(ffhb_t) :: hb
+  type(ffhc_t) :: hc
+  type(ffhd_t) :: hd
   integer      :: i
+  integer(int64) :: k64, v64
 
+  ! int -> string
   call ha%ustore_value(1, "hello world")
   print *, ha%fget_value(1)
-  if (ha%fget_value(1) /= "hello world") error stop "FAILED"
+  if (ha%fget_value(1) /= "hello world") error stop "FAILED ha"
 
+  ! string -> int
   call hb%ustore_value("first", 12345)
   print *, hb%fget_value("first")
-  if (hb%fget_value("first") /= 12345) error stop "FAILED"
+  if (hb%fget_value("first") /= 12345) error stop "FAILED hb"
 
-  ! Try to store the same key twice
   call hb%store_key("first", i)
-
-  ! Now an error should be thrown when setting a key twice
-  hb%existing_key_is_error = .true.
-  call hb%store_key("first", i)
+  call hb%store_key("first", i, existing_key_is_error = .true.)
   if (i /= -2) error stop "Expected -2 for duplicate key"
 
+  ! int64 -> int64
+  k64 = 9876543210123456_int64
+  v64 = 1234567890123456_int64
+  call hc%ustore_value(k64, v64)
+  print *, hc%fget_value(k64)
+  if (hc%fget_value(k64) /= v64) error stop "FAILED hc"
+
+  ! int64 -> string
+  call hd%ustore_value(k64, "64-bit key works")
+  print *, hd%fget_value(k64)
+  if (hd%fget_value(k64) /= "64-bit key works") error stop "FAILED hd"
+
   print *, "PASSED"
+
   call ha%reset()
   call hb%reset()
+  call hc%reset()
+  call hd%reset()
 end program test


### PR DESCRIPTION
As discussed, I am sending this pull request.
The following changes have been implemented in comparison to 
the `master` branch:

**README.md**
- Added description for `convert_key`, `FFH_STRING_XXX_TYPE` 
  (with `XXX = KEY` or `VAL`), and `FFH_ENABLE_INT64`.
- Removed outdated references to `FFH_XXX_STRING`.

**ffhash_inc.f90**
- Introduced preprocessor variables `FFH_ENABLE_INT64` and 
  `FFH_INT_KIND` (the latter used only locally).
- Replaced `FFH_XXX_IS_STRING` with `FFH_STRING_XXX_TYPE`; 
  `FFH_XXX_TYPE` is now overwritten if the string type is defined.
- Made `existing_key_is_error` local and optional in `store_key` / `store_val`.
- Removed the `pure` marker from `store_key` / `store_value` 
  (to allow custom key types containing pointers, e.g. 
   `class(*), pointer :: geo`).
- Included `FFH_CUSTOM_CONVERT_KEY` support from your 
   `custom_convert_key` branch.
- Added private `default_hash_core` function to switch between the different 
  `Murmur3` implementations.
- Integrated your Murmur3 x128 version and wrapped the hash functions 
   under `#ifdef FFH_ENABLE_INT64 … #else … #endif`.

**example_multiple_tables.f90**
- Replaced `FFH_XXX_IS_STRING` with `FFH_STRING_XXX_TYPE`.
- Added two examples demonstrating `FFH_ENABLE_INT64`.

**example_custom_key_types.f90**
- Included example from the `custom_convert_key` branch.

**example_custom_hash_function.f90**
- Replaced `FFH_XXX_IS_STRING` with `FFH_STRING_XXX_TYPE`.

**example_benchmark.f90**
- Added `use iso_fortran_env` due to reliance on `int32` and `int64` 
   from `ffhash`.

**Note:**
   I tried, but failed to adapt the code to use `character(:), allocatable` keys directly, 
without derived types.

You might add a warning in README.md that `character(:), allocatable` keys/values are 
(currently) not supported in a direct way.

Please let me know if you have questions/comments.

Thanks for considering this PR.